### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -2,6 +2,9 @@ name: Commit Lint - Conventional Commits
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   main:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/PiTScz/eslint-config-typescript/security/code-scanning/1](https://github.com/PiTScz/eslint-config-typescript/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow. Since the workflow only checks out the repository and runs commit linting, it likely only needs `contents: read` permission. This ensures that the `GITHUB_TOKEN` has the least privilege necessary to perform the workflow tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
